### PR TITLE
Format code samples on installation correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,7 @@ GO
 Install go domain extension for sphinx.
 
 .. code:: bash
+
   pip install go sphinxcontrib_golangdomain
 
 
@@ -161,11 +162,13 @@ Install a git client for your environment (e.g. from https://desktop.github.com/
 Install our godocjson tool (preprocess godoc output to JSON, in a way similar to jsdoc -X).
 
 .. code:: bash
+
   go get github.com/rtfd/godocjson
 
 Add go domain in your conf.py.
 
 .. code:: python
+
   extensions = [ 'sphinxcontrib.golangdomain',...
 
 Before running building your doc, make sure the godocjson executable is in your path.
@@ -180,6 +183,7 @@ Install nodejs on your platform.
 Install jsdoc using npm.
 
 .. code:: bash
+
   npm install jsdoc -g
 
 Before building your doc, make sure the jsdoc executable is in your path.


### PR DESCRIPTION
The code samples for the GO/JS installation steps were not showing up correctly due to missing line.


<img width="867" alt="screen shot 2018-02-14 at 2 50 51 pm" src="https://user-images.githubusercontent.com/4967458/36232436-a3cf1ff4-1196-11e8-9424-465499fe0841.png">
